### PR TITLE
Updated required laravel version to 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.5.0",
         "fzaninotto/faker": "~1.0",
-        "laravel/framework": "5.1.*",
+        "laravel/framework": "5.*",
         "phpdocumentor/reflection-docblock": "3.1.*",
         "doctrine/annotations": "1.2.*"
     },


### PR DESCRIPTION
Instead of 5.1.* this change enables to use the library in 5.* versions.